### PR TITLE
French dates

### DIFF
--- a/app/views/travels/index.html.erb
+++ b/app/views/travels/index.html.erb
@@ -5,8 +5,8 @@
   <div>
     <%= link_to travel_path(travel) do %>
       <%= travel.name %>
-      du <%= travel.travel_start_date %>
-      au <%= travel.travel_end_date %>
+      du <%= l travel.travel_start_date %>
+      au <%= l travel.travel_end_date %>
     <% end %>
   </div>
   <% end %>

--- a/app/views/travels/show.html.erb
+++ b/app/views/travels/show.html.erb
@@ -3,10 +3,10 @@
 
 
 <%= @travel.name %>
-du <%= @travel.travel_start_date %>
-au <%= @travel.travel_end_date %>
+du <%= l @travel.travel_start_date %>
+au <%= l @travel.travel_end_date %>
 <br>
-Durée globale: <%= @travel.travel_end_date - @travel.travel_start_date %>
+Durée globale: <%= (@travel.travel_end_date - @travel.travel_start_date).to_i %> jours
 <br>
 Pays:
 <% @travel.countries.each do |country| %>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -1,8 +1,8 @@
 <h1><%= @vaccine.name %></h1>
 <p>Description: <%= @vaccine.description %></p>
-<p>Début du traitement: <%= @vaccine.treatment_start_date %></p>
-<p>Fin du traitement: <%= @vaccine.treatment_end_date %></p>
-<p>Date limite d'administration: <%= @vaccine.injection_max_date %></p>
+<p>Début du traitement: <%= l @vaccine.treatment_start_date %></p>
+<p>Fin du traitement: <%= l @vaccine.treatment_end_date %></p>
+<p>Date limite d'administration: <%= l @vaccine.injection_max_date %></p>
 <p>Contre-indications: <%= @vaccine.contraindications %></p>
 <p>prix approximatif: <%= @vaccine.price %></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,26 @@
 
 en:
   hello: "Hello world"
+en:
+  date:
+    formats:
+      default: "%d %B %Y"
+    month_names:
+    -
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
+    order:
+    - :day
+    - :month
+    - :year
+


### PR DESCRIPTION
# French Dates
## Note 
Pour afficher une date au bon format, il faudra obligatoirement devancer le code ruby par la lettre "l" en minuscule, suivi d'un espace, pour indiquer à rails qu'il doit formatter la date. 
ex : `<%= l @travel.travel_start_date %>`

(voir capture d'écran en dessous)

### Added

- **Settings** : in the en.yml config file to display dates in the french way. (_/config/en.yml_)
- **"l" letter** : in some views to test the french display (note : it works)
- **to_i** : to the "durée globale" calclulation to avoid the "17/1" jours display
<img width="671" alt="Capture d’écran 2020-03-24 à 14 16 13" src="https://user-images.githubusercontent.com/58357600/77429673-4d930400-6dda-11ea-805e-26139d9194a1.png">
