### PR TITLE
Profile Update - without current password

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,8 @@
+class RegistrationsController < Devise::RegistrationsController
+
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
 
   <div class="form-inputs">
     <%= f.input :avatar, as: :file %>
-    <%= f.input :email, required: true, autofocus: true, label: t(".email") %>
+    <%= f.input :email, required: true, autofocus: true, label: t(".email"), disabled: true %>
     <%= f.input :username, required: true, autofocus: true, label: t(".username") %>
     <%= f.input :nationality, required: false, autofocus: true, disabled: true, hint: t(".nationality-fr"), label: t(".nationality") %>
     <%= f.input :date_of_birth, :as => :hidden, input_html: {class: "datePicker"}, required: false, autofocus: true, label: t(".dob") %>
@@ -15,18 +15,6 @@
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p><%= t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) %></p>
     <% end %>
-
-    <%= f.input :password,
-                hint: t(".leave_blank_if_you_don_t_want_to_change_it"),
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :current_password,
-                hint: t(".we_need_your_current_password_to_confirm_your_changes"),
-                required: true,
-                input_html: { autocomplete: "current-password" } %>
   </div>
 
   <div class="form-actions">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,8 @@
 <div><%= @user.email %></div>
 <div><%= @user.phone_number %></div>
 <div><% if ! @user.date_of_birth.nil? %> <%= @user.def_age %> <%= t(".years-old") %><% end %></div>
-<div><%= @user.gender %></div>
+<div><%= I18n.t :"user_genders.#{@user.gender}" %></div>
+
 
 <%= link_to edit_user_registration_path do %>
       <p><%= t('.edit') %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks', registrations: 'registrations' }
 
 
   scope "(:locale)", locale: /en|es/ do


### PR DESCRIPTION
User can edit information without current password confirmation, cannot change email address or password though.
Done because of problems with FB or Google connexion (automatic password generated, not known, user couldn't update information)